### PR TITLE
Compiler issues on iOS 6

### DIFF
--- a/NSString+HTML.m
+++ b/NSString+HTML.m
@@ -5,23 +5,23 @@
 //  Created by Johan Kool on 13-11-09.
 //  Copyright 2009-2011 Koolistov Pte. Ltd. All rights reserved.
 //
-//  Redistribution and use in source and binary forms, with or without modification, are 
+//  Redistribution and use in source and binary forms, with or without modification, are
 //  permitted provided that the following conditions are met:
 //
-//  * Redistributions of source code must retain the above copyright notice, this list of 
+//  * Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-//  * Neither the name of KOOLISTOV PTE. LTD. nor the names of its contributors may be used to 
-//    endorse or promote products derived from this software without specific prior written 
+//  * Neither the name of KOOLISTOV PTE. LTD. nor the names of its contributors may be used to
+//    endorse or promote products derived from this software without specific prior written
 //    permission.
 //
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
-//  THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
-//  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
-//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+//  THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+//  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+//  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
@@ -54,107 +54,107 @@
                           @"&igrave;", @"&iacute;", @"&icirc;", @"&iuml;", @"&eth;", @"&ntilde;", @"&ograve;",
                           @"&oacute;", @"&ocirc;", @"&otilde;", @"&ouml;", @"&divide;", @"&oslash;", @"&ugrave;",
                           @"&uacute;", @"&ucirc;", @"&uuml;", @"&yacute;", @"&thorn;", @"&yuml;", nil];
-
+		
         NSUInteger i, count = [codes count];
-
+		
         // Html
         for (i = 0; i < count; i++) {
             NSRange range = [self rangeOfString:[codes objectAtIndex:i]];
             if (range.location != NSNotFound) {
                 [escaped replaceOccurrencesOfString:[codes objectAtIndex:i]
-                                         withString:[NSString stringWithFormat:@"%C", 160 + i]
+                                         withString:[NSString stringWithFormat:@"%C", @(160 + i).unsignedShortValue]
                                             options:NSLiteralSearch
                                               range:NSMakeRange(0, [escaped length])];
             }
         }
-
+		
         // The following five are not in the 160+ range
-
+		
         // @"&amp;"
         NSRange range = [self rangeOfString:@"&amp;"];
         if (range.location != NSNotFound) {
             [escaped replaceOccurrencesOfString:@"&amp;"
-                                     withString:[NSString stringWithFormat:@"%C", 38]
+                                     withString:[NSString stringWithFormat:@"%C", @(38).unsignedShortValue]
                                         options:NSLiteralSearch
                                           range:NSMakeRange(0, [escaped length])];
         }
-
+		
         // @"&lt;"
         range = [self rangeOfString:@"&lt;"];
         if (range.location != NSNotFound) {
             [escaped replaceOccurrencesOfString:@"&lt;"
-                                     withString:[NSString stringWithFormat:@"%C", 60]
+                                     withString:[NSString stringWithFormat:@"%C", @(60).unsignedShortValue]
                                         options:NSLiteralSearch
                                           range:NSMakeRange(0, [escaped length])];
         }
-
+		
         // @"&gt;"
         range = [self rangeOfString:@"&gt;"];
         if (range.location != NSNotFound) {
             [escaped replaceOccurrencesOfString:@"&gt;"
-                                     withString:[NSString stringWithFormat:@"%C", 62]
+                                     withString:[NSString stringWithFormat:@"%C", @(62).unsignedShortValue]
                                         options:NSLiteralSearch
                                           range:NSMakeRange(0, [escaped length])];
         }
-
+		
         // @"&apos;"
         range = [self rangeOfString:@"&apos;"];
         if (range.location != NSNotFound) {
             [escaped replaceOccurrencesOfString:@"&apos;"
-                                     withString:[NSString stringWithFormat:@"%C", 39]
+                                     withString:[NSString stringWithFormat:@"%C", @(39).unsignedShortValue]
                                         options:NSLiteralSearch
                                           range:NSMakeRange(0, [escaped length])];
         }
-
+		
         // @"&quot;"
         range = [self rangeOfString:@"&quot;"];
         if (range.location != NSNotFound) {
             [escaped replaceOccurrencesOfString:@"&quot;"
-                                     withString:[NSString stringWithFormat:@"%C", 34]
+                                     withString:[NSString stringWithFormat:@"%C", @(34).unsignedShortValue]
                                         options:NSLiteralSearch
                                           range:NSMakeRange(0, [escaped length])];
         }
-
+		
         // Decimal & Hex
         NSRange start, finish, searchRange = NSMakeRange(0, [escaped length]);
         i = 0;
-
+		
         while (i < [escaped length]) {
             start = [escaped rangeOfString:@"&#"
                                    options:NSCaseInsensitiveSearch
                                      range:searchRange];
-
+			
             finish = [escaped rangeOfString:@";"
                                     options:NSCaseInsensitiveSearch
                                       range:searchRange];
-
+			
             if (start.location != NSNotFound && finish.location != NSNotFound &&
                 finish.location > start.location) {
                 NSRange entityRange = NSMakeRange(start.location, (finish.location - start.location) + 1);
                 NSString *entity = [escaped substringWithRange:entityRange];
                 NSString *value = [entity substringWithRange:NSMakeRange(2, [entity length] - 2)];
-
+				
                 [escaped deleteCharactersInRange:entityRange];
-
+				
                 if ([value hasPrefix:@"x"]) {
                     unsigned tempInt = 0;
                     NSScanner *scanner = [NSScanner scannerWithString:[value substringFromIndex:1]];
                     [scanner scanHexInt:&tempInt];
-                    [escaped insertString:[NSString stringWithFormat:@"%C", tempInt] atIndex:entityRange.location];
+                    [escaped insertString:[NSString stringWithFormat:@"%C", @(tempInt).unsignedShortValue] atIndex:entityRange.location];
                 } else {
-                    [escaped insertString:[NSString stringWithFormat:@"%C", [value intValue]] atIndex:entityRange.location];
+                    [escaped insertString:[NSString stringWithFormat:@"%C", @([value intValue]).unsignedShortValue] atIndex:entityRange.location];
                 } i = start.location;
             } else { i++; }
             searchRange = NSMakeRange(i, [escaped length] - i);
         }
-
+		
         return escaped;    // Note this is autoreleased
     }
 }
 
 - (NSString *)kv_encodeHTMLCharacterEntities {
     NSMutableString *encoded = [NSMutableString stringWithString:self];
-
+	
     // @"&amp;"
     NSRange range = [self rangeOfString:@"&"];
     if (range.location != NSNotFound) {
@@ -163,7 +163,7 @@
                                     options:NSLiteralSearch
                                       range:NSMakeRange(0, [encoded length])];
     }
-
+	
     // @"&lt;"
     range = [self rangeOfString:@"<"];
     if (range.location != NSNotFound) {
@@ -172,7 +172,7 @@
                                     options:NSLiteralSearch
                                       range:NSMakeRange(0, [encoded length])];
     }
-
+	
     // @"&gt;"
     range = [self rangeOfString:@">"];
     if (range.location != NSNotFound) {
@@ -181,7 +181,7 @@
                                     options:NSLiteralSearch
                                       range:NSMakeRange(0, [encoded length])];
     }
-
+	
     return encoded;
 }
 


### PR DESCRIPTION
There were compiler warnings on iOS 6 complaining of the usage of integers instead of unsigned shorts. Easy fix.
